### PR TITLE
Added two cmd flags for database connection

### DIFF
--- a/cmd/carpenter/command/before.go
+++ b/cmd/carpenter/command/before.go
@@ -14,11 +14,16 @@ var db *sql.DB
 var schema string
 var verbose bool
 var dryrun bool
+var maxIdleConns int
+var maxOpenConns int
 
 func Before(c *cli.Context) error {
 	verbose = c.GlobalBool("verbose")
 	dryrun = c.GlobalBool("dry-run")
 	schema = c.GlobalString("schema")
+	maxIdleConns = c.GlobalInt("max-idle-conns")
+	maxOpenConns = c.GlobalInt("max-open-conns")
+
 	if len(schema) <= 0 {
 		return fmt.Errorf("err: Specify required `--schema' option")
 	}
@@ -31,8 +36,8 @@ func Before(c *cli.Context) error {
 	if err != nil {
 		return fmt.Errorf("err: db.Open is failed for reason %v", err)
 	}
-	db.SetMaxIdleConns(1)
-	db.SetMaxOpenConns(1)
+	db.SetMaxIdleConns(maxIdleConns)
+	db.SetMaxOpenConns(maxOpenConns)
 	db.SetConnMaxLifetime(time.Minute)
 	return nil
 }

--- a/cmd/carpenter/commands.go
+++ b/cmd/carpenter/commands.go
@@ -29,6 +29,18 @@ var GlobalFlags = []cli.Flag{
 		Usage:  "data source name like '[username[:password]@][tcp[(address:port)]]' (required)",
 		Hidden: false,
 	},
+	cli.IntFlag{
+		Name:   "max-idle-conns, mi",
+		Usage:  "max idel database connection setting",
+		Hidden: false,
+		Value:  0,
+	},
+	cli.IntFlag{
+		Name:   "max-open-conns, mo",
+		Usage:  "max open database connection setting",
+		Hidden: false,
+		Value:  8,
+	},
 }
 
 var Commands = []cli.Command{


### PR DESCRIPTION
I added two flags as command line arguments.

- --max-idle-conns is for max idle connection setting for sql.DB
- --max-open-conns is for max open connection setting for sql.DB

see also the discuss: https://github.com/dev-cloverlab/carpenter/pull/32